### PR TITLE
add -fno-permissive to avoid invalid conversion from ‘napi_finalize’ {aka ‘void (*)(napi_env__*, void*, void*)’} to ‘node_api_nogc_finalize’

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -22,7 +22,7 @@
             '-lodbc'
           ],
           'cflags' : [
-            '-g'
+            '-g', '-fno-permissive'
           ]
         }],
         [ 'OS == "mac"', {


### PR DESCRIPTION
probably not the best option but gets it to build and stops the error 

```
invalid conversion from ‘napi_finalize’ {aka ‘void (*)(napi_env__*, void*, void*)’} to ‘node_api_nogc_finalize’
```

partially for https://github.com/IBM/node-odbc/issues/392 .  Solves my immediate issue but doesn't solve that there isn't pre-built binaries for ppc64le and build time errors are occurring from dependency changes else where in node ecosystem.

Note i still need to test and verify if ignoring the issue above causes other problems