### PR TITLE
Drop support for NAPI 7 and below

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,10 +57,7 @@
     "host": "https://github.com/markdirish/node-odbc/releases/download/v{version}",
     "package_name": "{name}-v{version}-{platform}-{arch}-napi-v{napi_build_version}.tar.gz",
     "napi_versions": [
-      3,
-      4,
-      5,
-      6
+      8
     ]
   }
 }

--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -705,14 +705,12 @@ void ODBC::StoreBindValues(Napi::Array *values, Parameter **parameters) {
       parameter->ValueType = SQL_C_DEFAULT;
       parameter->ParameterValuePtr = NULL;
       parameter->StrLen_or_IndPtr = SQL_NULL_DATA;
-#if NAPI_VERSION > 5
     } else if (value.IsBigInt()) {
       // TODO: need to check for signed/unsigned?
       bool lossless = true;
       parameter->ValueType = SQL_C_SBIGINT;
       parameter->ParameterValuePtr = new SQLBIGINT(value.As<Napi::BigInt>().Int64Value(&lossless));
       parameter->isbigint = true;
-#endif
     } else if (value.IsNumber()) {
       double double_val = value.As<Napi::Number>().DoubleValue();
       int64_t int_val = value.As<Napi::Number>().Int64Value();

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -1180,7 +1180,6 @@ void ODBCConnection::ParametersToArray(Napi::Reference<Napi::Array> *napiParamet
             value = Napi::Number::New(env, *(SQLUINTEGER*)parameter->ParameterValuePtr);
             break;
           // Napi::BigInt
-#if NAPI_VERSION > 5
           case SQL_C_SBIGINT:
             if (parameter->isbigint ==  true) {
               value = Napi::BigInt::New(env, *(int64_t*)parameter->ParameterValuePtr);
@@ -1195,14 +1194,6 @@ void ODBCConnection::ParametersToArray(Napi::Reference<Napi::Array> *napiParamet
               value = Napi::Number::New(env, *(uint64_t*)parameter->ParameterValuePtr);
             }
             break;
-#else
-          case SQL_C_SBIGINT:
-            value = Napi::Number::New(env, *(int64_t*)parameter->ParameterValuePtr);
-            break;
-          case SQL_C_UBIGINT:
-            value = Napi::Number::New(env, *(uint64_t*)parameter->ParameterValuePtr);
-            break;
-#endif
           case SQL_C_SSHORT:
             value = Napi::Number::New(env, *(signed short*)parameter->ParameterValuePtr);
             break;
@@ -4204,11 +4195,7 @@ Napi::Array process_data_for_napi(Napi::Env env, StatementData *data, Napi::Arra
           case SQL_BIGINT:
             switch(columns[j]->bind_type) {
               case SQL_C_SBIGINT:
-#if NAPI_VERSION > 5
                 value = Napi::BigInt::New(env, (int64_t)storedRow[j].bigint_data);
-#else
-                value = Napi::Number::New(env, (int64_t)storedRow[j].bigint_data);
-#endif
                 break;
               default:
                 value = Napi::String::New(env, (char*)storedRow[j].char_data);


### PR DESCRIPTION
This allows us to only build for one NAPI version instead of 4 and removes a separate code path for NAPI versions older than 6. We technically don't use anything newer than 6, but may as well go to 8 since that supports all Node.js versions we care about (and even some we don't).

https://nodejs.org/api/n-api.html#node-api-version-matrix