### PR TITLE
Fix various typos and reference issues in Cursor.js

### DIFF
--- a/lib/Cursor.js
+++ b/lib/Cursor.js
@@ -1,9 +1,9 @@
 class Cursor {
 
-  static CUSROR_CLOSED_ERROR = 'Cursor has already been closed!';
+  static CURSOR_CLOSED_ERROR = 'Cursor has already been closed!';
 
   /**
-   * An cursor created following the execution of query that is ready to return a result set 
+   * An cursor created following the execution of query that is ready to return a result set
    * @constructor
    * @param {object} odbcCursor - an odbcCursor object, defined in src/odbc_cursor.h/.cpp
    */
@@ -19,7 +19,7 @@ class Cursor {
   get noData() {
     if (!this.odbcCursor)
     {
-      throw new Error(CUSROR_CLOSED_ERROR);
+      throw new Error(Cursor.CURSOR_CLOSED_ERROR);
     }
     return this.odbcCursor.noData;
   }
@@ -35,7 +35,7 @@ class Cursor {
 
     if (typeof callback !== 'function') {
       if (!this.odbcCursor) {
-        throw new Error(Cursor.CUSROR_CLOSED_ERROR);
+        throw new Error(Cursor.CURSOR_CLOSED_ERROR);
       }
       return new Promise((resolve, reject) => {
         this.odbcCursor.fetch((error, result) => {
@@ -49,7 +49,7 @@ class Cursor {
     }
 
     if (!this.odbcCursor) {
-      callback(new Error(Cursor.CUSROR_CLOSED_ERROR));
+      callback(new Error(Cursor.CURSOR_CLOSED_ERROR));
     } else {
       this.odbcCursor.fetch(callback);
     }
@@ -65,7 +65,7 @@ class Cursor {
     // promise...
     if (typeof callback !== 'function') {
       if (!this.odbcCursor) {
-        throw new Error(Cursor.CUSROR_CLOSED_ERROR);
+        throw new Error(Cursor.CURSOR_CLOSED_ERROR);
       }
       return new Promise((resolve, reject) => {
         this.odbcCursor.close((error) => {

--- a/lib/Cursor.js
+++ b/lib/Cursor.js
@@ -26,7 +26,7 @@ class Cursor {
 
   /**
    * Calls SQL_FETCH and returns the next result set
-   * @param {function} [callback] - The callback function to return an error and a result. If the callback is ommited, a Promise is returned.
+   * @param {function} [cb] - The callback function to return an error and a result. If the callback is ommited, a Promise is returned.
    * @returns {undefined|Promise}
    */
   fetch(cb) {


### PR DESCRIPTION
- the noData getter threw the wrong Error Reference
- CURSOR was misspelled CUSROR
- The cb param was documented as callback