### PR TITLE
ci: Update Node and action versions for PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
         node-version:
           - 20.x
         os:
-          - windows-latest
+          - windows-2022
           - ubuntu-latest
           - macos-latest
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,9 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install dependencies


### PR DESCRIPTION
Adjust PR workflow to address Node 20 being deprecated within GitHub actions.

- Node 20 fails on windows-latest and is EOL, update to Node 22.
- Update actions/checkout and actions/setup-node to latest versions which now use Node 24.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners