### PR TITLE
doc: update npm install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Three main steps must be done before `node-odbc` can interact with your database
 When all these steps have been completed, install `node-odbc` into your Node.js project by using:
 
 ```bash
+# node-odbc uses node-pre-gyp install scripts
+# npm v12+ requires approval for install scripts to run
+# https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/
+npm --approve-scripts odbc
+
 npm install odbc
 ```
 ---


### PR DESCRIPTION
With npm v12, `npm install` will no longer automatically run scripts from your package dependencies, but instead must be explicitly marked as allowed/trusted. This is to reduce the potential for malware and the effect of other recent supply chain attacks to be performed.

node-odbc uses node-pre-gyp to automatically install a pre-built node binding from the corresponding GitHub release or fall back to building it from source if a pre-built is not available. Starting with npm v12, the node-pre-gyp install script will no longer be run unless explicitly allowed using `npm approve-scripts odbc`.

Fixes #478